### PR TITLE
SDI-2861 Replace cout statements with logging

### DIFF
--- a/examples/collector/src/Makefile
+++ b/examples/collector/src/Makefile
@@ -29,7 +29,7 @@ IDIRS=-I.
 LDIRS=-L.
 CFLAGS=-std=c++1y
 #LIBS= -lsnap -lgrpc++ -lprotobuf -lz -lpthread -lboost_program_options
-LIBS=-Wl,--start-group $(SNAPLIBS)/libsnap.a $(SNAPLIBS)/libgrpc.a $(SNAPLIBS)/libgrpc++.a $(SNAPLIBS)/libprotobuf.a $(BOOSTLIBS)/libboost_program_options.a -Wl,--end-group -lz -lpthread
+LIBS=-Wl,--start-group $(SNAPLIBS)/libsnap.a $(SNAPLIBS)/libgrpc.a $(SNAPLIBS)/libgrpc++.a $(SNAPLIBS)/libprotobuf.a $(BOOSTLIBS)/libboost_program_options.a -Wl,--end-group -lz -lpthread -lssl -lcrypto
 FILES := $(wildcard *.cc)
 
 all: $(TARGET)				# Build all targets

--- a/examples/collector/src/rando.cc
+++ b/examples/collector/src/rando.cc
@@ -13,14 +13,17 @@ limitations under the License.
 */
 #include "rando.h"
 
+#include <iostream>
+#include <string>
 #include <time.h>
 #include <vector>
-#include <iostream>
 
 #include <snap/config.h>
 #include <snap/plugin.h>
 #include <snap/metric.h>
 #include <snap/flags.h>
+
+#include <spdlog/spdlog.h>
 
 using Plugin::Config;
 using Plugin::ConfigPolicy;
@@ -28,9 +31,6 @@ using Plugin::Metric;
 using Plugin::Meta;
 using Plugin::Type;
 using Plugin::Flags;
-
-using std::cout;
-using std::endl;
 
 const ConfigPolicy Rando::get_config_policy() {
     ConfigPolicy policy;
@@ -87,6 +87,8 @@ void Rando::collect_metrics(std::vector<Metric> &metrics) {
 }
 
 int main(int argc, char **argv) {
+    std::shared_ptr<spd::logger> logger = spdlog::stdout_logger_mt("rando");
+
     Flags cli;
     cli.SetFlags();
     cli.ParseFlags(argc, argv);
@@ -94,7 +96,7 @@ int main(int argc, char **argv) {
     Meta meta(Type::Collector, "rando", 1);
 
     if (cli.GetFlagsVM().count("version")) {
-        cout << meta.name << " version "  << meta.version << endl;
+        logger->info(meta.name + " version " + std::to_string(meta.version));
         exit(0);
     }
     if (cli.GetFlagsVM().count("stand-alone")) {

--- a/examples/processor/src/Makefile
+++ b/examples/processor/src/Makefile
@@ -27,7 +27,7 @@ CC=g++
 IDIRS=-I.
 LDIRS=-L.
 CFLAGS=-std=c++1y
-LIBS=-Wl,--start-group $(SNAPLIBS)/libsnap.a $(SNAPLIBS)/libgrpc.a $(SNAPLIBS)/libgrpc++.a $(SNAPLIBS)/libprotobuf.a -Wl,--end-group -lz -lpthread
+LIBS=-Wl,--start-group $(SNAPLIBS)/libsnap.a $(SNAPLIBS)/libgrpc.a $(SNAPLIBS)/libgrpc++.a $(SNAPLIBS)/libprotobuf.a -Wl,--end-group -lz -lpthread -lssl -lcrypto
 FILES := $(wildcard *.cc)
 
 all: $(TARGET)				# Build all targets

--- a/examples/publisher/src/Makefile
+++ b/examples/publisher/src/Makefile
@@ -27,7 +27,7 @@ CC=g++
 IDIRS=-I.
 LDIRS=-L.
 CFLAGS=-std=c++1y
-LIBS=-Wl,--start-group $(SNAPLIBS)/libsnap.a $(SNAPLIBS)/libgrpc.a $(SNAPLIBS)/libgrpc++.a $(SNAPLIBS)/libprotobuf.a -Wl,--end-group -lz -lpthread
+LIBS=-Wl,--start-group $(SNAPLIBS)/libsnap.a $(SNAPLIBS)/libgrpc.a $(SNAPLIBS)/libgrpc++.a $(SNAPLIBS)/libprotobuf.a -Wl,--end-group -lz -lpthread -lssl -lcrypto
 FILES := $(wildcard *.cc)
 
 all: $(TARGET)				# Build all targets

--- a/src/snap/flags.cc
+++ b/src/snap/flags.cc
@@ -294,14 +294,14 @@ int Plugin::Flags::ParseFlags(const int &argc, char **argv,
 void Plugin::Flags::ShowVariablesMap() {
     try {
         for (const auto& it : _flags) {
-            std::cout << it.first.c_str() << " ";
+            _logger->info(it.first.c_str());
             auto& value = it.second.value();
             if (auto v = boost::any_cast<bool>(&value))
-                std::cout << *v << std::endl;
+                _logger->info(*v);
             else if (auto v = boost::any_cast<int>(&value))
-                std::cout << *v << std::endl;
+                _logger->info(*v);
             else if (auto v = boost::any_cast<std::string>(&value))
-                std::cout << *v << std::endl;
+                _logger->info(*v);
             else
                 _logger->warn("variable map value type not supported");
         }

--- a/src/snap/flags.h
+++ b/src/snap/flags.h
@@ -98,29 +98,29 @@ namespace Plugin {
         void SetFlagsLogLevel(const int &logLevel = 2);
 
         int helpFlagCalled() {
-            std::cout << _visible << std::endl;
+            _logger->info(_visible);
             return 0;
         }
 
         po::options_description GetCommandOptions() { return _command; }
-        void PrintCommandOptions() { std::cout << _command << std::endl; }
+        void PrintCommandOptions() { _logger->info(_command); }
 
         po::options_description GetGlobalOptions() { return _global; }
-        void PrintGlobalOptions() { std::cout << _global << std::endl; }
+        void PrintGlobalOptions() {_logger->info( _global); }
 
         po::options_description GetHiddenOptions() { return _hidden; }
-        void PrintHiddenOptions() { std::cout << _hidden << std::endl; }
+        void PrintHiddenOptions() {_logger->info( _hidden); }
 
         po::options_description GetAdditionalOptions() { return _additional; }
-        void PrintAdditionalOptions() { std::cout << _additional << std::endl; }
+        void PrintAdditionalOptions() { _logger->info(_additional); }
 
         po::options_description GetVisibleOptions() { return _visible; }
-        void PrintVisibleOptions() { std::cout << _visible << std::endl; }
+        void PrintVisibleOptions() { _logger->info(_visible); }
 
         po::options_description GetCommandLineOptions() { return _command_line; }
-        void PrintCommandLineOptions() { std::cout << _command_line << std::endl; }
+        void PrintCommandLineOptions() { _logger->info(_command_line); }
 
         po::options_description GetConfigFileOptions() { return _config_file; }
-        void PrintConfigFileOptions() { std::cout << _config_file << std::endl; }
+        void PrintConfigFileOptions() { _logger->info(_config_file); }
     };
 } // namespace Plugin

--- a/src/snap/proxy/plugin_proxy.cc
+++ b/src/snap/proxy/plugin_proxy.cc
@@ -14,6 +14,8 @@ limitations under the License.
 #include <grpc++/grpc++.h>
 #include <iostream>
 #include <thread>
+#include <string>
+#include <ctime>
 
 #include "snap/proxy/plugin_proxy.h"
 #include "snap/rpc/plugin.pb.h"
@@ -34,8 +36,9 @@ PluginImpl::PluginImpl(Plugin::PluginInterface* plugin) : plugin(plugin) {}
 Status PluginImpl::Ping(ServerContext* context, const Empty* req,
                         ErrReply* resp) {
     _lastPing = std::chrono::system_clock::now();
-    // Change to log
-    std::cout << "Heartbeat received at: " << _lastPing << std::endl;
+    std::time_t t = std::chrono::system_clock::to_time_t(_lastPing);
+    std::string time(std::ctime(&t));
+    _logger->info("Heartbeat received at: " + time);
     return Status::OK;
 }
 
@@ -51,21 +54,22 @@ Status PluginImpl::GetConfigPolicy(ServerContext* context, const Empty* req,
 }
 
 void PluginImpl::HeartbeatWatch() {
+    _logger = spdlog::stdout_logger_mt("Heart Beat Watch");
     _lastPing = std::chrono::system_clock::now();
-    std::cout << "Heartbeat started" << std::endl;
+    _logger->info("Heartbeat started");
     int count = 0;
     while (1) {
         if ((std::chrono::system_clock::now() - _lastPing).count() >= _pingTimeoutDuration.count()) {
             ++count;
-            std::cout << "Heartbeat timeout " << count 
-                        << " of " << _pingTimeoutLimit 
-                        << ".  (Duration between checks " << _pingTimeoutDuration.count() << ")" << std::endl;
+            _logger->info("Heartbeat timeout " + std::to_string(count) +
+                          " of " + std::to_string( _pingTimeoutLimit) +
+                          ".  (Duration between checks " + std::to_string(_pingTimeoutDuration.count()) + ")");
             if (count >= _pingTimeoutLimit) {
-                std::cout << "Heartbeat timeout expired!" << std::endl;
+                _logger->info("Heartbeat timeout expired!");
                 exit(0);
             }
         } else {
-            std::cout << "Heartbeat timeout reset";
+            _logger->info("Heartbeat timeout reset");
             count = 0;
         }
         std::this_thread::sleep_for(_pingTimeoutDuration);

--- a/src/snap/proxy/plugin_proxy.h
+++ b/src/snap/proxy/plugin_proxy.h
@@ -12,14 +12,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 #pragma once
-#include <iostream>
 #include <chrono>
 #include <ctime>
-#include <iomanip>
 #include <grpc++/grpc++.h>
+#include <iomanip>
+#include <iostream>
+#include <spdlog/spdlog.h>
 
 #include "snap/rpc/plugin.pb.h"
 #include "snap/plugin.h"
+
+namespace spd = spdlog;
 
 namespace Plugin {
     namespace Proxy {
@@ -60,6 +63,7 @@ namespace Plugin {
 
         private:
             Plugin::PluginInterface* plugin;
+            std::shared_ptr<spd::logger> _logger;
             std::chrono::system_clock::time_point _lastPing;
             // PingTimeoutLimit is the number of successively missed pin health checks
             // which must occur before the plugin is stopped


### PR DESCRIPTION
Problem: Currently most of our logging is done utilizing cout
statements. We want to improve this by utilizing the spdlog logging
library.

Solution: I've made appropriate changes to flags.h, flags.cc, and
rando.cc in order to get logging working correctly.

Testing: I didn't see any testing available, so I manually tested using the
rando plugin. 

NOTES: I had to add -lssl and -lcrypto linking to the Makefiles for the
examples in order to compile correctly on my system. Not sure if this is
the case for other people, but these changes are included in this
commit.
I also removed some incomplete code from plugin.cc to compile, changes
to plugin.cc are not included in this commit.

File Changes:
- examples/*/src/Makefile
  Added -lssl and -lcrypto

- examples/collector/src/rando.cc
  Added rando specific logger.

- src/snap/flags.cc
  Added logger capability to ShowVariableMap function

- src/snap/flags.h
  Replaced about 8 cout commands with logger.
